### PR TITLE
Changed condition in ValidateArchitecture.cs

### DIFF
--- a/Bleak/Services/ValidateArchitecture.cs
+++ b/Bleak/Services/ValidateArchitecture.cs
@@ -28,7 +28,7 @@ namespace Bleak.Services
             
             // Ensure that x64 injection is not being attempted from an x86 process
 
-            if (!Environment.Is64BitProcess && isWow64)
+            if (Environment.Is64BitOperatingSystem && !Environment.Is64BitProcess && !isWow64)
             {
                 throw new ApplicationException("x64 injection is not supported when compiled as x86");
             }


### PR DESCRIPTION
Ensure that x64 injection is not being attempted from an x86 process, changed condition
(Injecting to 64-bit process from a 32-bit process isn't supported, that is only a thing on a 64-bit os)